### PR TITLE
fix: Add feedback for option button

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -10,21 +10,28 @@ const styles = stylex.create({
     alignItems: "center",
     justifyContent: "center",
     padding: "8px 16px",
+    userSelect: "none",
   },
   p: {
     color: "#fff",
     fontWeight: "600",
     fontFamily: "'Rubik', serif",
     fontSize: 16,
+    pointerEvents: "none",
   },
   span: {
     marginRight: 8,
+    pointerEvents: "none",
   },
   settings: {
     marginLeft: 8,
     padding: 0,
     background: "transparent",
     border: "none",
+    ":hover": {
+      cursor: "pointer",
+      filter: "brightness(0.8)",
+    },
   },
   dev: {
     display: "flex",


### PR DESCRIPTION
設定ボタンを押せることをわかりやすくする & テキストや 🦐 を選択できないように。
<img width="133" height="87" alt="CleanShot 2025-09-18 at 21 33 27" src="https://github.com/user-attachments/assets/c8480cb3-572c-48b2-9bdd-a303abc59f98" />
<img width="133" height="87" alt="CleanShot 2025-09-18 at 21 33 10" src="https://github.com/user-attachments/assets/7ed9f645-e98f-4a37-96e1-5fc31a3539b7" />
