### PR TITLE
fix: Add biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,10 +21,17 @@
       "recommended": true,
       "correctness": {
         "useExhaustiveDependencies": "warn",
-        "useHookAtTopLevel": "error"
+        "useHookAtTopLevel": "error",
+        "noUnusedImports": "error"
+      },
+      "suspicious": {
+        "noConsole": "error",
+        "noExplicitAny": "error",
+        "noArrayIndexKey": "error"
       },
       "style": {
-        "useComponentExportOnlyModules": "error"
+        "useComponentExportOnlyModules": "error",
+        "useImportType": "error"
       }
     }
   },

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -3,7 +3,7 @@ import {
   loadShortcuts,
   matchesShortcut,
   onShortcutsChanged,
-  ShortcutConfig,
+  type ShortcutConfig,
 } from "../utils/shortcuts";
 
 type MODE_TYPE = "normal" | "insert" | "visual";

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 import * as stylex from "@stylexjs/stylex";
 import {
   loadShortcuts,
@@ -6,7 +7,7 @@ import {
   getShortcutString,
   parseKeyboardEvent,
   validateShortcut,
-  ShortcutConfig,
+  type ShortcutConfig,
   DEFAULT_SHORTCUTS,
 } from "../utils/shortcuts";
 


### PR DESCRIPTION
以下のルールを追加しました。

```
   "correctness": {
        "useExhaustiveDependencies": "warn", // React Hooks の依存配列チェック
        "useHookAtTopLevel": "error",       // Hooks はトップレベルで使用
        "noUnusedImports": "error"          // 未使用インポートを禁止
      },
      "suspicious": {
        "noConsole": "error",       // console.log などを禁止
        "noExplicitAny": "error",   // any 型の明示を禁止
        "noArrayIndexKey": "error"  // key に配列インデックス使用を禁止
      },
      "style": {
        "useComponentExportOnlyModules": "error", // コンポーネントのみエクスポート
        "useImportType": "error"                  // Type 用の import を使う
      }
```

Lazyvimで[こちら](https://www.lazyvim.org/extras/formatting/biome)のprettierの設定をオフにして、masonでbiomeを入れると動きました。