### PR TITLE
fix: fix unintended pos increment on newline

### DIFF
--- a/src/commands/normal.ts
+++ b/src/commands/normal.ts
@@ -49,7 +49,7 @@ export const NORMAL_COMMANDS: Record<string, Command> = {
     }
   },
   right: ({ start, end, col, lines, currentLine }) => {
-    if (col !== lines[currentLine].length - 1)
+    if (col !== (lines[currentLine].length || 1) - 1)
       return { start: start + 1, end: end + 1 };
   },
   join_line: ({ start, end, element }) => {


### PR DESCRIPTION
改行コード `\n` しかない行で <kbd>l</kbd> を押すと `pos` が意図せずインクリメントされる不具合を修正。

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

https://github.com/user-attachments/assets/38226c39-44c6-4918-ab9a-c3328b775964

</td>
<td>

https://github.com/user-attachments/assets/35213532-24fb-4ea7-82f2-9d98daa3e733

</td>
</tr>
</table>