### PR TITLE
fix: Reset mode on blur

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -26,6 +26,8 @@ export default defineContentScript({
 
     const keydown = async (e: KeyboardEvent) =>
       ({ mode, pos } = await handleKeyDown(e, { mode, pos }, keymaps));
+    const resetMode = () => (mode = "insert");
     window.addEventListener("keydown", keydown);
+    window.addEventListener("focusout", resetMode);
   },
 });


### PR DESCRIPTION
`textarea` や `input` がフォーカスを失うごとに `insert mode` にリセットする。