### PR TITLE
feat: normal modeでキャレットの自動スクロール機能を追加

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -1,24 +1,26 @@
 <!doctype html>
 <html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>evi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&family=Rubik:ital,wght@1,600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../src/styles/reset.css" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>evi</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&family=Rubik:ital,wght@1,600&display=swap"
-    rel="stylesheet" />
-  <link rel="stylesheet" href="../src/styles/reset.css" />
-  <link rel="stylesheet" href="./style.css" />
-</head>
-
-<body>
-  <div class="App">
-    <p class="App__text">evi Dev Mode</p>
-    <input class="App__child" name="input" type="text" value="aaaaa" />
-    <textarea class="App__child" name="textarea">aaaaa&#10;bbbbb&#10;ccccc</textarea>
-  </div>
-</body>
-
+  <body>
+    <div class="App">
+      <p class="App__text">evi Dev Mode</p>
+      <input class="App__child" name="input" type="text" value="aaaaa" />
+      <textarea class="App__child" name="textarea">
+aaaaa&#10;bbbbb&#10;ccccc&#10;ddddd&#10;eeeee&#10;fffff&#10;ggggg&#10;hhhhh&#10;iiiii&#10;jjjjj&#10;kkkkk&#10;lllll&#10;mmmmm&#10;nnnnn&#10;ooooo&#10;ppppp&#10;qqqqq&#10;rrrrr&#10;sssss&#10;ttttt&#10;uuuuu&#10;vvvvv&#10;wwwww&#10;xxxxx&#10;yyyyy&#10;zzzzz</textarea
+      >
+    </div>
+  </body>
 </html>

--- a/src/commands/normal.ts
+++ b/src/commands/normal.ts
@@ -173,8 +173,10 @@ export const NORMAL_COMMANDS: Record<string, Command> = {
   },
   undo: () => {
     document.execCommand("undo");
+    return undefined;
   },
   redo: () => {
     document.execCommand("redo");
+    return undefined;
   },
 };

--- a/src/utils/handleKeyDown.ts
+++ b/src/utils/handleKeyDown.ts
@@ -12,6 +12,7 @@ import {
   getElement,
   getLines,
   getMaxKeyHistory,
+  scrollToCaret,
   sendMessage,
 } from "@/utils";
 
@@ -115,6 +116,11 @@ export const handleKeyDown = async (
     newPos.start ?? args.pos.start,
     newPos.end ?? args.pos.end,
   );
+
+  // Auto-scroll to keep caret visible in normal mode
+  if (mode === "normal") {
+    scrollToCaret(element, newPos.start ?? args.pos.start);
+  }
 
   if (newMode && newMode !== mode) {
     sendMessage<Badge>({

--- a/src/utils/handleKeyDown.ts
+++ b/src/utils/handleKeyDown.ts
@@ -117,7 +117,7 @@ export const handleKeyDown = async (
     newPos.end ?? args.pos.end,
   );
 
-  // Auto-scroll to keep caret visible in normal mode
+  // normal mode時にキャレットが見える範囲に自動スクロール
   if (mode === "normal") {
     scrollToCaret(element, newPos.start ?? args.pos.start);
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,5 +6,6 @@ export * from "./getLines";
 export * from "./getMaxKeyHistory";
 export * from "./handleKeyDown";
 export * from "./insertText";
+export * from "./scrollToCaret";
 export * from "./shortcuts";
 export * from "./types";

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -1,11 +1,10 @@
-import { getLines } from "@/utils";
-
 const SCROLL_PADDING_LINES = 2;
 const DEFAULT_LINE_HEIGHT = 16;
 
 /**
  * キャレットが画面内に見えるようにtextareaをスクロールする
  * textarea要素のみ対応（input要素はスクロール非対応）
+ * テキストの折り返しを考慮して正確な位置を計算する
  *
  * @param element - inputまたはtextarea要素
  * @param caretPosition - キャレット位置（選択範囲の開始位置）
@@ -13,12 +12,9 @@ const DEFAULT_LINE_HEIGHT = 16;
 export const scrollToCaret = (
   element: HTMLInputElement | HTMLTextAreaElement,
   caretPosition: number,
-): void => {
+) => {
   // textarea要素のみスクロール対応
   if (!(element instanceof HTMLTextAreaElement)) return;
-
-  // 既存のユーティリティを使って行情報を取得（currentLineは0-based）
-  const { currentLine } = getLines(element, caretPosition);
 
   // 計算スタイルから行の高さを取得
   const style = window.getComputedStyle(element);
@@ -27,8 +23,9 @@ export const scrollToCaret = (
     Number.parseFloat(style.fontSize) ||
     DEFAULT_LINE_HEIGHT;
 
-  // 位置を計算
-  const caretTop = currentLine * lineHeight;
+  // 折り返しを考慮してキャレットの実際のY位置を計算
+  const caretTop = getCaretTopPosition(element, caretPosition, style);
+
   const scrollTop = element.scrollTop;
   const clientHeight = element.clientHeight;
   const padding = lineHeight * SCROLL_PADDING_LINES;
@@ -41,4 +38,52 @@ export const scrollToCaret = (
   else if (caretTop + lineHeight > scrollTop + clientHeight - padding) {
     element.scrollTop = caretTop + lineHeight - clientHeight + padding;
   }
+};
+
+/**
+ * テキストの折り返しを考慮してキャレットの実際のY位置を取得
+ * 測定用の一時div要素を使用してtextareaと同じレンダリング結果を得る
+ *
+ * @param element - textarea要素
+ * @param caretPosition - キャレット位置
+ * @param style - textareaの計算済みスタイル
+ * @returns キャレットのY位置（ピクセル）
+ */
+const getCaretTopPosition = (
+  element: HTMLTextAreaElement,
+  caretPosition: number,
+  style: CSSStyleDeclaration,
+) => {
+  // 測定用の一時div要素を作成
+  const measureDiv = document.createElement("div");
+
+  // textareaと同じスタイルを適用（折り返し動作を再現）
+  measureDiv.style.position = "absolute";
+  measureDiv.style.visibility = "hidden";
+  measureDiv.style.whiteSpace = "pre-wrap"; // textareaと同じ折り返し動作
+  measureDiv.style.wordWrap = "break-word";
+  measureDiv.style.overflowWrap = style.overflowWrap;
+  measureDiv.style.width = style.width;
+  measureDiv.style.fontFamily = style.fontFamily;
+  measureDiv.style.fontSize = style.fontSize;
+  measureDiv.style.fontWeight = style.fontWeight;
+  measureDiv.style.fontStyle = style.fontStyle;
+  measureDiv.style.lineHeight = style.lineHeight;
+  measureDiv.style.letterSpacing = style.letterSpacing;
+  measureDiv.style.padding = style.padding;
+  measureDiv.style.border = style.border;
+  measureDiv.style.boxSizing = style.boxSizing;
+
+  // キャレット位置までのテキストをコピー
+  const textBeforeCaret = element.value.substring(0, caretPosition);
+  measureDiv.textContent = textBeforeCaret;
+
+  // DOMに追加して測定
+  document.body.appendChild(measureDiv);
+  const height = measureDiv.scrollHeight;
+  document.body.removeChild(measureDiv);
+
+  // paddingTopを引いた実際のテキスト高さを返す
+  const paddingTop = Number.parseFloat(style.paddingTop) || 0;
+  return height - paddingTop;
 };

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -1,0 +1,45 @@
+import { getLines } from "@/utils";
+
+const SCROLL_PADDING_LINES = 2;
+
+/**
+ * Scrolls the textarea to ensure the caret is visible within the viewport.
+ * Only works for textarea elements (input elements don't support scrolling).
+ *
+ * @param element - The input or textarea element
+ * @param caretPosition - The caret position (start of selection)
+ */
+export const scrollToCaret = (
+  element: HTMLInputElement | HTMLTextAreaElement,
+  caretPosition: number,
+): void => {
+  // Only textarea elements support scrolling
+  if (element.tagName !== "TEXTAREA") return;
+
+  const textarea = element as HTMLTextAreaElement;
+
+  // Get line info using existing utility
+  const { currentLine } = getLines(element, caretPosition);
+
+  // Calculate line height from computed styles
+  const style = window.getComputedStyle(textarea);
+  const lineHeight =
+    Number.parseFloat(style.lineHeight) ||
+    Number.parseFloat(style.fontSize) ||
+    16;
+
+  // Calculate positions
+  const caretTop = currentLine * lineHeight;
+  const scrollTop = textarea.scrollTop;
+  const clientHeight = textarea.clientHeight;
+  const padding = lineHeight * SCROLL_PADDING_LINES;
+
+  // Scroll up if caret is too close to top edge
+  if (caretTop < scrollTop + padding) {
+    textarea.scrollTop = Math.max(0, caretTop - padding);
+  }
+  // Scroll down if caret is too close to bottom edge
+  else if (caretTop + lineHeight > scrollTop + clientHeight - padding) {
+    textarea.scrollTop = caretTop + lineHeight - clientHeight + padding;
+  }
+};

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -1,6 +1,7 @@
 import { getLines } from "@/utils";
 
 const SCROLL_PADDING_LINES = 2;
+const DEFAULT_LINE_HEIGHT = 16;
 
 /**
  * Scrolls the textarea to ensure the caret is visible within the viewport.
@@ -18,7 +19,7 @@ export const scrollToCaret = (
 
   const textarea = element as HTMLTextAreaElement;
 
-  // Get line info using existing utility
+  // Get line info using existing utility (currentLine is 0-based)
   const { currentLine } = getLines(element, caretPosition);
 
   // Calculate line height from computed styles
@@ -26,7 +27,7 @@ export const scrollToCaret = (
   const lineHeight =
     Number.parseFloat(style.lineHeight) ||
     Number.parseFloat(style.fontSize) ||
-    16;
+    DEFAULT_LINE_HEIGHT;
 
   // Calculate positions
   const caretTop = currentLine * lineHeight;

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -4,42 +4,42 @@ const SCROLL_PADDING_LINES = 2;
 const DEFAULT_LINE_HEIGHT = 16;
 
 /**
- * Scrolls the textarea to ensure the caret is visible within the viewport.
- * Only works for textarea elements (input elements don't support scrolling).
+ * キャレットが画面内に見えるようにtextareaをスクロールする
+ * textarea要素のみ対応（input要素はスクロール非対応）
  *
- * @param element - The input or textarea element
- * @param caretPosition - The caret position (start of selection)
+ * @param element - inputまたはtextarea要素
+ * @param caretPosition - キャレット位置（選択範囲の開始位置）
  */
 export const scrollToCaret = (
   element: HTMLInputElement | HTMLTextAreaElement,
   caretPosition: number,
 ): void => {
-  // Only textarea elements support scrolling
+  // textarea要素のみスクロール対応
   if (element.tagName !== "TEXTAREA") return;
 
   const textarea = element as HTMLTextAreaElement;
 
-  // Get line info using existing utility (currentLine is 0-based)
+  // 既存のユーティリティを使って行情報を取得（currentLineは0-based）
   const { currentLine } = getLines(element, caretPosition);
 
-  // Calculate line height from computed styles
+  // 計算スタイルから行の高さを取得
   const style = window.getComputedStyle(textarea);
   const lineHeight =
     Number.parseFloat(style.lineHeight) ||
     Number.parseFloat(style.fontSize) ||
     DEFAULT_LINE_HEIGHT;
 
-  // Calculate positions
+  // 位置を計算
   const caretTop = currentLine * lineHeight;
   const scrollTop = textarea.scrollTop;
   const clientHeight = textarea.clientHeight;
   const padding = lineHeight * SCROLL_PADDING_LINES;
 
-  // Scroll up if caret is too close to top edge
+  // キャレットが上端に近い場合は上にスクロール
   if (caretTop < scrollTop + padding) {
     textarea.scrollTop = Math.max(0, caretTop - padding);
   }
-  // Scroll down if caret is too close to bottom edge
+  // キャレットが下端に近い場合は下にスクロール
   else if (caretTop + lineHeight > scrollTop + clientHeight - padding) {
     textarea.scrollTop = caretTop + lineHeight - clientHeight + padding;
   }

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -11,9 +11,7 @@ const measureDivCache = new WeakMap<HTMLTextAreaElement, HTMLDivElement>();
  * @param element - textarea要素
  * @returns 測定用のdiv要素
  */
-const getOrCreateMeasureDiv = (
-  element: HTMLTextAreaElement,
-): HTMLDivElement => {
+const getOrCreateMeasureDiv = (element: HTMLTextAreaElement) => {
   let measureDiv = measureDivCache.get(element);
 
   if (!measureDiv) {

--- a/src/utils/scrollToCaret.ts
+++ b/src/utils/scrollToCaret.ts
@@ -15,15 +15,13 @@ export const scrollToCaret = (
   caretPosition: number,
 ): void => {
   // textarea要素のみスクロール対応
-  if (element.tagName !== "TEXTAREA") return;
-
-  const textarea = element as HTMLTextAreaElement;
+  if (!(element instanceof HTMLTextAreaElement)) return;
 
   // 既存のユーティリティを使って行情報を取得（currentLineは0-based）
   const { currentLine } = getLines(element, caretPosition);
 
   // 計算スタイルから行の高さを取得
-  const style = window.getComputedStyle(textarea);
+  const style = window.getComputedStyle(element);
   const lineHeight =
     Number.parseFloat(style.lineHeight) ||
     Number.parseFloat(style.fontSize) ||
@@ -31,16 +29,16 @@ export const scrollToCaret = (
 
   // 位置を計算
   const caretTop = currentLine * lineHeight;
-  const scrollTop = textarea.scrollTop;
-  const clientHeight = textarea.clientHeight;
+  const scrollTop = element.scrollTop;
+  const clientHeight = element.clientHeight;
   const padding = lineHeight * SCROLL_PADDING_LINES;
 
   // キャレットが上端に近い場合は上にスクロール
   if (caretTop < scrollTop + padding) {
-    textarea.scrollTop = Math.max(0, caretTop - padding);
+    element.scrollTop = Math.max(0, caretTop - padding);
   }
   // キャレットが下端に近い場合は下にスクロール
   else if (caretTop + lineHeight > scrollTop + clientHeight - padding) {
-    textarea.scrollTop = caretTop + lineHeight - clientHeight + padding;
+    element.scrollTop = caretTop + lineHeight - clientHeight + padding;
   }
 };


### PR DESCRIPTION
normal mode時にキャレットが画面外に移動した際に自動的にスクロールする機能を実装しました。j/k等の移動コマンドでカーソルが常に見える範囲に表示されるようになります。


https://github.com/user-attachments/assets/3045e8a7-b828-4bea-962b-12cc445fe4ae



変更内容:
- scrollToCaretユーティリティを作成してtextareaのスクロール処理を実装
- handleKeyDownでカーソル位置更新後にスクロールロジックを統合
- undo/redoコマンドの型エラーを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)