### PR TITLE
feat: ContentEditable要素でのVimキー操作サポート追加

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -18,6 +18,7 @@
     <p class="App__text">evi Dev Mode</p>
     <input class="App__child" name="input" type="text" value="aaaaa" />
     <textarea class="App__child" name="textarea">aaaaa&#10;bbbbb&#10;ccccc</textarea>
+    <div class="App__child" contenteditable="true">aaaaa<br>bbbbb<br>ccccc</div>
   </div>
 </body>
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -21,9 +21,7 @@
       <textarea class="App__child" name="textarea">
 aaaaa&#10;bbbbb&#10;ccccc&#10;ddddd&#10;eeeee&#10;fffff&#10;ggggg&#10;hhhhh&#10;iiiii&#10;jjjjj&#10;kkkkk&#10;lllll&#10;mmmmm&#10;nnnnn&#10;ooooo&#10;ppppp&#10;qqqqq&#10;rrrrr&#10;sssss&#10;ttttt&#10;uuuuu&#10;vvvvv&#10;wwwww&#10;xxxxx&#10;yyyyy&#10;zzzzz</textarea
       >
-      <div class="App__child" contenteditable="true">
-        aaaaa<br />bbbbb<br />ccccc
-      </div>
+      <div class="App__child" contenteditable="true">aaaaa<br />bbbbb<br />ccccc</div>
     </div>
   </body>
 </html>

--- a/dev/style.css
+++ b/dev/style.css
@@ -44,6 +44,7 @@ body {
 }
 
 .App__child {
+  background-color: #fff;
   border: none;
   border-radius: 4px;
   padding: 8px;

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -1,4 +1,5 @@
 import { type Command, insertText } from "@/utils";
+import { getText } from "@/utils/elementHelpers";
 
 export const COMMON_COMMANDS: Record<string, Command> = {
   delete_char_insert: ({ start, end, element }) => {
@@ -6,8 +7,9 @@ export const COMMON_COMMANDS: Record<string, Command> = {
     return { start, end: start, mode: "insert" };
   },
   delete_line_insert: ({ start, end, element, length }) => {
-    const prevBreak = element.value.lastIndexOf("\n", start) + 1;
-    const nextBreak = element.value.indexOf("\n", end);
+    const text = getText(element);
+    const prevBreak = text.lastIndexOf("\n", start) + 1;
+    const nextBreak = text.indexOf("\n", end);
     start = prevBreak === -1 ? 0 : prevBreak;
     end = nextBreak === -1 ? length : nextBreak;
     insertText(element, start, end, "");

--- a/src/commands/insert.ts
+++ b/src/commands/insert.ts
@@ -1,16 +1,21 @@
 import type { Command } from "@/utils";
+import {
+  getSelectionRange,
+  getText,
+  setSelectionRange,
+} from "@/utils/elementHelpers";
 
 export const INSERT_COMMANDS: Record<string, Command> = {
   enter_normal_mode: ({ element, start, end, length, lines, currentLine }) => {
-    start = element.selectionStart || 0;
+    start = getSelectionRange(element).start || 0;
     if (
       start === length ||
-      (lines[currentLine].length && element.value.charAt(start) === "\n")
+      (lines[currentLine].length && getText(element).charAt(start) === "\n")
     ) {
       start--;
     }
     end = start + 1;
-    element.setSelectionRange(start, end);
+    setSelectionRange(element, start, end);
     return { start, end, mode: "normal" };
   },
 };

--- a/src/commands/normal.ts
+++ b/src/commands/normal.ts
@@ -13,9 +13,10 @@ export const NORMAL_COMMANDS: Record<string, Command> = {
     if (!lines[currentLine].length) end--;
     return { start: end, end, mode: "insert" };
   },
-  insert_end: ({ start, end, element }) => {
+  insert_end: ({ start, end, element, length }) => {
     const text = getText(element);
-    start = end = text.indexOf("\n", start);
+    const nextBreak = text.indexOf("\n", start);
+    start = end = nextBreak === -1 ? length : nextBreak;
     return { start, end, mode: "insert" };
   },
   left: ({ start, end, col }) => {

--- a/src/commands/normal.ts
+++ b/src/commands/normal.ts
@@ -128,7 +128,7 @@ export const NORMAL_COMMANDS: Record<string, Command> = {
     return { start, end };
   },
   insert_below: ({ start, end, element, length }) => {
-    // Support multiline elements (TEXTAREA and contenteditable, but not INPUT)
+    // 複数行をサポートする要素（TEXTAREAとcontenteditable、INPUTは除外）
     if (!(element instanceof HTMLInputElement)) {
       const text = getText(element);
       const nextBreak = text.indexOf("\n", start);
@@ -139,7 +139,7 @@ export const NORMAL_COMMANDS: Record<string, Command> = {
     }
   },
   insert_above: ({ start, end, element }) => {
-    // Support multiline elements (TEXTAREA and contenteditable, but not INPUT)
+    // 複数行をサポートする要素（TEXTAREAとcontenteditable、INPUTは除外）
     if (!(element instanceof HTMLInputElement)) {
       const text = getText(element);
       const prevBreak = text.lastIndexOf("\n", start - 1);

--- a/src/commands/visual.ts
+++ b/src/commands/visual.ts
@@ -110,7 +110,7 @@ export const VISUAL_COMMANDS: Record<string, Command> = {
     const text = window.getSelection()?.toString();
     if (text) {
       navigator.clipboard.writeText(text);
-      // Get current selection range and delete the text
+      // 現在の選択範囲を取得してテキストを削除
       const { start, end } = getSelectionRange(element);
       insertText(element, start, end, "");
       return { start: oStart, end: oEnd, mode: "normal" };

--- a/src/commands/visual.ts
+++ b/src/commands/visual.ts
@@ -1,4 +1,5 @@
 import { type Command, insertText } from "@/utils";
+import { getSelectionRange, getText } from "@/utils/elementHelpers";
 
 export const VISUAL_COMMANDS: Record<string, Command> = {
   expand_left: ({ start, end, oStart }) => {
@@ -82,7 +83,8 @@ export const VISUAL_COMMANDS: Record<string, Command> = {
     return { start, end };
   },
   delete: ({ element, start, end, length }) => {
-    if (element.value.charAt(start - 1) === "\n" && end === length) start--;
+    const text = getText(element);
+    if (text.charAt(start - 1) === "\n" && end === length) start--;
     insertText(element, start, end, "");
     if (end === length) start--;
     end = start + 1;
@@ -108,7 +110,9 @@ export const VISUAL_COMMANDS: Record<string, Command> = {
     const text = window.getSelection()?.toString();
     if (text) {
       navigator.clipboard.writeText(text);
-      element.setRangeText("");
+      // Get current selection range and delete the text
+      const { start, end } = getSelectionRange(element);
+      insertText(element, start, end, "");
       return { start: oStart, end: oEnd, mode: "normal" };
     }
   },

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -37,9 +37,7 @@ export const getText = (
         }
         if (
           node instanceof Element &&
-          (node.tagName === "BR" ||
-            node.tagName === "DIV" ||
-            node.tagName === "P")
+          ["BR", "DIV", "P"].includes(node.tagName)
         ) {
           return NodeFilter.FILTER_ACCEPT;
         }
@@ -59,7 +57,7 @@ export const getText = (
       if (node.tagName === "BR") {
         text += "\n";
         prevWasBlock = false;
-      } else if (node.tagName === "DIV" || node.tagName === "P") {
+      } else if (["DIV", "P"].includes(node.tagName)) {
         // 最初のブロック要素以外は改行を追加
         if (text.length > 0 && !prevWasBlock) {
           text += "\n";
@@ -179,9 +177,7 @@ const getTextContentLength = (range: Range): number => {
         }
         if (
           node instanceof Element &&
-          (node.tagName === "BR" ||
-            node.tagName === "DIV" ||
-            node.tagName === "P")
+          ["BR", "DIV", "P"].includes(node.tagName)
         ) {
           return NodeFilter.FILTER_ACCEPT;
         }
@@ -201,7 +197,7 @@ const getTextContentLength = (range: Range): number => {
       if (node.tagName === "BR") {
         length += 1;
         prevWasBlock = false;
-      } else if (node.tagName === "DIV" || node.tagName === "P") {
+      } else if (["DIV", "P"].includes(node.tagName)) {
         if (length > 0 && !prevWasBlock) {
           length += 1;
         }
@@ -233,9 +229,7 @@ const getNodeAndOffset = (
         }
         if (
           node instanceof Element &&
-          (node.tagName === "BR" ||
-            node.tagName === "DIV" ||
-            node.tagName === "P")
+          ["BR", "DIV", "P"].includes(node.tagName)
         ) {
           return NodeFilter.FILTER_ACCEPT;
         }
@@ -289,7 +283,7 @@ const getNodeAndOffset = (
         }
         currentOffset += 1;
         prevWasBlock = false;
-      } else if (node.tagName === "DIV" || node.tagName === "P") {
+      } else if (["DIV", "P"].includes(node.tagName)) {
         // ブロック要素による改行
         if (currentOffset > 0 && !prevWasBlock) {
           if (currentOffset >= targetOffset) {

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -1,0 +1,221 @@
+/**
+ * Helper functions to abstract differences between INPUT/TEXTAREA and contenteditable elements
+ */
+
+/**
+ * Check if an element is contenteditable
+ */
+export const isContentEditable = (
+  element: Element | null,
+): element is HTMLElement => {
+  return element instanceof HTMLElement && element.isContentEditable;
+};
+
+/**
+ * Get text content from an element (works with INPUT, TEXTAREA, and contenteditable)
+ */
+export const getText = (
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
+): string => {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return element.value;
+  }
+
+  // For contenteditable, convert HTML to plain text
+  // Replace <br> and <div> with newlines
+  const clone = element.cloneNode(true) as HTMLElement;
+
+  // Replace <br> with newline
+  clone.querySelectorAll("br").forEach((br) => {
+    br.replaceWith("\n");
+  });
+
+  // Replace block elements with newlines
+  clone.querySelectorAll("div, p").forEach((block, index) => {
+    if (index > 0) {
+      block.prepend(document.createTextNode("\n"));
+    }
+  });
+
+  return clone.textContent || "";
+};
+
+/**
+ * Get text length from an element
+ */
+export const getTextLength = (
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
+): number => {
+  return getText(element).length;
+};
+
+/**
+ * Get current selection range from an element
+ */
+export const getSelectionRange = (
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
+): { start: number; end: number } => {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return {
+      start: element.selectionStart ?? 0,
+      end: element.selectionEnd ?? 0,
+    };
+  }
+
+  // For contenteditable, calculate offset from window selection
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return { start: 0, end: 0 };
+  }
+
+  const range = selection.getRangeAt(0);
+
+  // Calculate start and end offsets relative to element's text content
+  const preSelectionRange = range.cloneRange();
+  preSelectionRange.selectNodeContents(element);
+  preSelectionRange.setEnd(range.startContainer, range.startOffset);
+  const start = getTextContentLength(preSelectionRange);
+
+  const end = start + getTextContentLength(range);
+
+  return { start, end };
+};
+
+/**
+ * Set selection range on an element
+ */
+export const setSelectionRange = (
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
+  start: number,
+  end: number,
+): void => {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    element.setSelectionRange(start, end);
+    return;
+  }
+
+  // For contenteditable, use Range API
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  const range = document.createRange();
+  const { node: startNode, offset: startOffset } = getNodeAndOffset(
+    element,
+    start,
+  );
+  const { node: endNode, offset: endOffset } = getNodeAndOffset(element, end);
+
+  if (startNode && endNode) {
+    try {
+      range.setStart(startNode, startOffset);
+      range.setEnd(endNode, endOffset);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    } catch (_e) {
+      // If setting range fails, just place cursor at start
+      range.setStart(startNode, startOffset);
+      range.setEnd(startNode, startOffset);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  }
+};
+
+/**
+ * Helper: Get text content length from a Range, accounting for line breaks
+ */
+const getTextContentLength = (range: Range): number => {
+  const container = document.createElement("div");
+  container.appendChild(range.cloneContents());
+
+  // Count <br> as newlines
+  const brCount = container.querySelectorAll("br").length;
+
+  // Count block elements as newlines (except the first one)
+  const blockCount = Math.max(
+    0,
+    container.querySelectorAll("div, p").length - 1,
+  );
+
+  return (container.textContent || "").length + brCount + blockCount;
+};
+
+/**
+ * Helper: Find the text node and offset for a given character position
+ */
+const getNodeAndOffset = (
+  element: HTMLElement,
+  targetOffset: number,
+): { node: Node; offset: number } => {
+  let currentOffset = 0;
+
+  const walker = document.createTreeWalker(
+    element,
+    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode: (node) => {
+        // Accept text nodes and <br> elements
+        if (node.nodeType === Node.TEXT_NODE) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
+        if (
+          node.nodeType === Node.ELEMENT_NODE &&
+          (node as Element).tagName === "BR"
+        ) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
+        return NodeFilter.FILTER_SKIP;
+      },
+    },
+  );
+
+  let node: Node | null = walker.nextNode();
+
+  while (node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const textLength = node.textContent?.length || 0;
+      if (currentOffset + textLength >= targetOffset) {
+        return {
+          node,
+          offset: targetOffset - currentOffset,
+        };
+      }
+      currentOffset += textLength;
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      (node as Element).tagName === "BR"
+    ) {
+      // <br> counts as 1 character (newline)
+      if (currentOffset + 1 >= targetOffset) {
+        // Place cursor after the <br>
+        const childNodes = node.parentNode?.childNodes || [];
+        const nodeIndex = Array.prototype.findIndex.call(
+          childNodes,
+          (child) => child === node,
+        );
+        return {
+          node: node.parentNode || element,
+          offset: nodeIndex + 1,
+        };
+      }
+      currentOffset += 1;
+    }
+
+    node = walker.nextNode();
+  }
+
+  // If we couldn't find the exact position, return the last text node or element itself
+  return {
+    node: element.lastChild || element,
+    offset: element.lastChild?.textContent?.length || 0,
+  };
+};

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -259,11 +259,10 @@ const getNodeAndOffset = (
         // <br>を1文字（改行）としてカウント
         if (currentOffset >= targetOffset) {
           // <br>の前にカーソルを配置
-          const childNodes = node.parentNode?.childNodes || [];
-          const nodeIndex = Array.prototype.findIndex.call(
-            childNodes,
-            (child) => child === node,
-          );
+          const childNodes = node.parentNode?.childNodes;
+          const nodeIndex = childNodes
+            ? [...childNodes].findIndex((child) => child === node)
+            : -1;
           return {
             node: node.parentNode || element,
             offset: nodeIndex,
@@ -271,11 +270,10 @@ const getNodeAndOffset = (
         }
         if (currentOffset + 1 > targetOffset) {
           // <br>の後にカーソルを配置
-          const childNodes = node.parentNode?.childNodes || [];
-          const nodeIndex = Array.prototype.findIndex.call(
-            childNodes,
-            (child) => child === node,
-          );
+          const childNodes = node.parentNode?.childNodes;
+          const nodeIndex = childNodes
+            ? [...childNodes].findIndex((child) => child === node)
+            : -1;
           return {
             node: node.parentNode || element,
             offset: nodeIndex + 1,

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -1,9 +1,9 @@
 /**
- * Helper functions to abstract differences between INPUT/TEXTAREA and contenteditable elements
+ * INPUT/TEXTAREAとcontenteditable要素の違いを吸収するヘルパー関数群
  */
 
 /**
- * Check if an element is contenteditable
+ * 要素がcontenteditableかどうかを判定
  */
 export const isContentEditable = (
   element: Element | null,
@@ -12,7 +12,7 @@ export const isContentEditable = (
 };
 
 /**
- * Get text content from an element (works with INPUT, TEXTAREA, and contenteditable)
+ * 要素からテキスト内容を取得（INPUT、TEXTAREA、contenteditableに対応）
  */
 export const getText = (
   element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
@@ -24,16 +24,16 @@ export const getText = (
     return element.value;
   }
 
-  // For contenteditable, convert HTML to plain text
-  // Replace <br> and <div> with newlines
+  // contenteditableの場合、HTMLをプレーンテキストに変換
+  // <br>と<div>を改行に置換
   const clone = element.cloneNode(true) as HTMLElement;
 
-  // Replace <br> with newline
+  // <br>を改行に置換
   clone.querySelectorAll("br").forEach((br) => {
     br.replaceWith("\n");
   });
 
-  // Replace block elements with newlines
+  // ブロック要素を改行に置換
   clone.querySelectorAll("div, p").forEach((block, index) => {
     if (index > 0) {
       block.prepend(document.createTextNode("\n"));
@@ -44,7 +44,7 @@ export const getText = (
 };
 
 /**
- * Get text length from an element
+ * 要素のテキストの長さを取得
  */
 export const getTextLength = (
   element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
@@ -53,7 +53,7 @@ export const getTextLength = (
 };
 
 /**
- * Get current selection range from an element
+ * 要素の現在の選択範囲を取得
  */
 export const getSelectionRange = (
   element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
@@ -68,7 +68,7 @@ export const getSelectionRange = (
     };
   }
 
-  // For contenteditable, calculate offset from window selection
+  // contenteditableの場合、window.getSelection()からオフセットを計算
   const selection = window.getSelection();
   if (!selection || selection.rangeCount === 0) {
     return { start: 0, end: 0 };
@@ -76,7 +76,7 @@ export const getSelectionRange = (
 
   const range = selection.getRangeAt(0);
 
-  // Calculate start and end offsets relative to element's text content
+  // 要素のテキスト内容を基準にした開始・終了オフセットを計算
   const preSelectionRange = range.cloneRange();
   preSelectionRange.selectNodeContents(element);
   preSelectionRange.setEnd(range.startContainer, range.startOffset);
@@ -88,7 +88,7 @@ export const getSelectionRange = (
 };
 
 /**
- * Set selection range on an element
+ * 要素の選択範囲を設定
  */
 export const setSelectionRange = (
   element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
@@ -103,7 +103,7 @@ export const setSelectionRange = (
     return;
   }
 
-  // For contenteditable, use Range API
+  // contenteditableの場合、Range APIを使用
   const selection = window.getSelection();
   if (!selection) return;
 
@@ -121,7 +121,7 @@ export const setSelectionRange = (
       selection.removeAllRanges();
       selection.addRange(range);
     } catch (_e) {
-      // If setting range fails, just place cursor at start
+      // 範囲設定が失敗した場合は、開始位置にカーソルを配置
       range.setStart(startNode, startOffset);
       range.setEnd(startNode, startOffset);
       selection.removeAllRanges();
@@ -131,16 +131,16 @@ export const setSelectionRange = (
 };
 
 /**
- * Helper: Get text content length from a Range, accounting for line breaks
+ * ヘルパー: Rangeのテキスト内容の長さを取得（改行を考慮）
  */
 const getTextContentLength = (range: Range): number => {
   const container = document.createElement("div");
   container.appendChild(range.cloneContents());
 
-  // Count <br> as newlines
+  // <br>を改行としてカウント
   const brCount = container.querySelectorAll("br").length;
 
-  // Count block elements as newlines (except the first one)
+  // ブロック要素を改行としてカウント（最初の要素は除く）
   const blockCount = Math.max(
     0,
     container.querySelectorAll("div, p").length - 1,
@@ -150,7 +150,7 @@ const getTextContentLength = (range: Range): number => {
 };
 
 /**
- * Helper: Find the text node and offset for a given character position
+ * ヘルパー: 指定された文字位置に対応するテキストノードとオフセットを検索
  */
 const getNodeAndOffset = (
   element: HTMLElement,
@@ -163,7 +163,7 @@ const getNodeAndOffset = (
     NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
     {
       acceptNode: (node) => {
-        // Accept text nodes and <br> elements
+        // テキストノードと<br>要素を受け入れる
         if (node.nodeType === Node.TEXT_NODE) {
           return NodeFilter.FILTER_ACCEPT;
         }
@@ -194,9 +194,9 @@ const getNodeAndOffset = (
       node.nodeType === Node.ELEMENT_NODE &&
       (node as Element).tagName === "BR"
     ) {
-      // <br> counts as 1 character (newline)
+      // <br>を1文字（改行）としてカウント
       if (currentOffset + 1 >= targetOffset) {
-        // Place cursor after the <br>
+        // <br>の後にカーソルを配置
         const childNodes = node.parentNode?.childNodes || [];
         const nodeIndex = Array.prototype.findIndex.call(
           childNodes,
@@ -213,7 +213,7 @@ const getNodeAndOffset = (
     node = walker.nextNode();
   }
 
-  // If we couldn't find the exact position, return the last text node or element itself
+  // 正確な位置が見つからない場合、最後のテキストノードまたは要素自体を返す
   return {
     node: element.lastChild || element,
     offset: element.lastChild?.textContent?.length || 0,

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -260,9 +260,7 @@ const getNodeAndOffset = (
         if (currentOffset >= targetOffset) {
           // <br>の前にカーソルを配置
           const childNodes = node.parentNode?.childNodes;
-          const nodeIndex = childNodes
-            ? [...childNodes].findIndex((child) => child === node)
-            : -1;
+          const nodeIndex = childNodes ? [...childNodes].indexOf(node) : -1;
           return {
             node: node.parentNode || element,
             offset: nodeIndex,
@@ -271,9 +269,7 @@ const getNodeAndOffset = (
         if (currentOffset + 1 > targetOffset) {
           // <br>の後にカーソルを配置
           const childNodes = node.parentNode?.childNodes;
-          const nodeIndex = childNodes
-            ? [...childNodes].findIndex((child) => child === node)
-            : -1;
+          const nodeIndex = childNodes ? [...childNodes].indexOf(node) : -1;
           return {
             node: node.parentNode || element,
             offset: nodeIndex + 1,

--- a/src/utils/elementHelpers.ts
+++ b/src/utils/elementHelpers.ts
@@ -167,10 +167,7 @@ const getNodeAndOffset = (
         if (node.nodeType === Node.TEXT_NODE) {
           return NodeFilter.FILTER_ACCEPT;
         }
-        if (
-          node.nodeType === Node.ELEMENT_NODE &&
-          (node as Element).tagName === "BR"
-        ) {
+        if (node instanceof Element && node.tagName === "BR") {
           return NodeFilter.FILTER_ACCEPT;
         }
         return NodeFilter.FILTER_SKIP;
@@ -190,10 +187,7 @@ const getNodeAndOffset = (
         };
       }
       currentOffset += textLength;
-    } else if (
-      node.nodeType === Node.ELEMENT_NODE &&
-      (node as Element).tagName === "BR"
-    ) {
+    } else if (node instanceof Element && node.tagName === "BR") {
       // <br>を1文字（改行）としてカウント
       if (currentOffset + 1 >= targetOffset) {
         // <br>の後にカーソルを配置

--- a/src/utils/getElement.ts
+++ b/src/utils/getElement.ts
@@ -1,4 +1,17 @@
-export const getElement = (element: Element | null) =>
-  element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
-    ? element
-    : null;
+export const getElement = (
+  element: Element | null,
+): HTMLInputElement | HTMLTextAreaElement | HTMLElement | null => {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return element;
+  }
+
+  // Check if element is contenteditable
+  if (element instanceof HTMLElement && element.isContentEditable) {
+    return element;
+  }
+
+  return null;
+};

--- a/src/utils/getElement.ts
+++ b/src/utils/getElement.ts
@@ -8,7 +8,7 @@ export const getElement = (
     return element;
   }
 
-  // Check if element is contenteditable
+  // contenteditable要素かをチェック
   if (element instanceof HTMLElement && element.isContentEditable) {
     return element;
   }

--- a/src/utils/getLines.ts
+++ b/src/utils/getLines.ts
@@ -1,11 +1,13 @@
+import { getText } from "./elementHelpers";
+
 export const getLines = (
-  element: HTMLInputElement | HTMLTextAreaElement,
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
   start: number,
 ) => {
   let charCount = 0;
   let currentLine = 0;
   let col = 0;
-  const lines = element.value.split("\n");
+  const lines = getText(element).split("\n");
 
   for (let i = 0; i < lines.length; i++) {
     const linesLength = lines[i].length + 1;

--- a/src/utils/handleKeyDown.ts
+++ b/src/utils/handleKeyDown.ts
@@ -14,8 +14,11 @@ import {
   getMaxKeyHistory,
   sendMessage,
 } from "@/utils";
+import {
+  getTextLength,
+  setSelectionRange as setSelection,
+} from "./elementHelpers";
 
-const DOM_ARRAY = ["INPUT", "TEXTAREA"];
 let keyHistory: string[] = [];
 
 export const handleKeyDown = async (
@@ -25,15 +28,14 @@ export const handleKeyDown = async (
 ): Promise<Args> => {
   const activeElement = document.activeElement;
   const element = getElement(activeElement);
-  if (!element || !DOM_ARRAY.includes(element.tagName))
-    return { mode: args.mode, pos: args.pos };
+  if (!element) return { mode: args.mode, pos: args.pos };
 
   const { mode } = args;
 
   const combinedArgs = {
     mode,
     element,
-    length: element.value.length,
+    length: getTextLength(element),
     endCurrentLine: getLines(element, args.pos.end).currentLine,
     ...args.pos,
     ...getLines(element, args.pos.start),
@@ -111,7 +113,8 @@ export const handleKeyDown = async (
 
   const { mode: newMode, ...newPos } = newValues || {};
 
-  element.setSelectionRange(
+  setSelection(
+    element,
     newPos.start ?? args.pos.start,
     newPos.end ?? args.pos.end,
   );

--- a/src/utils/insertText.ts
+++ b/src/utils/insertText.ts
@@ -1,15 +1,38 @@
+import {
+  getTextLength,
+  setSelectionRange as setSelection,
+} from "./elementHelpers";
+
 export const insertText = (
-  element: HTMLInputElement | HTMLTextAreaElement,
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement,
   start: number,
   end: number,
   value: string,
 ) => {
-  element.setSelectionRange(start, end);
-  if (value === "" && element.value.length === end - start) {
+  // Set selection range (works for both INPUT/TEXTAREA and contenteditable)
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    element.setSelectionRange(start, end);
+  } else {
+    setSelection(element, start, end);
+  }
+
+  const textLength = getTextLength(element);
+
+  if (value === "" && textLength === end - start) {
     // 文字数が0になる場合は、操作不能に陥る不具合があるため
     // execCommandで一度スペースを挿入してから削除する
     document.execCommand("insertText", false, " ");
-    element.setSelectionRange(0, 1);
+    if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement
+    ) {
+      element.setSelectionRange(0, 1);
+    } else {
+      setSelection(element, 0, 1);
+    }
     document.execCommand("delete");
   } else if (value === "") {
     document.execCommand("delete");

--- a/src/utils/insertText.ts
+++ b/src/utils/insertText.ts
@@ -9,7 +9,7 @@ export const insertText = (
   end: number,
   value: string,
 ) => {
-  // Set selection range (works for both INPUT/TEXTAREA and contenteditable)
+  // 選択範囲を設定（INPUT/TEXTAREAとcontenteditableの両方に対応）
   if (
     element instanceof HTMLInputElement ||
     element instanceof HTMLTextAreaElement

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,7 +24,7 @@ export interface CombinedArgs extends Positions, Omit<Args, "pos"> {
   lines: string[];
   charCount: number;
   col: number;
-  element: HTMLInputElement | HTMLTextAreaElement;
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLElement;
   length: number;
 }
 


### PR DESCRIPTION
INPUT、TEXTAREA要素に加えて、contenteditable要素でもVimライクなキー操作が可能になりました。

## 変更内容

### 新規ファイル
- `src/utils/elementHelpers.ts`: INPUT/TEXTAREAとcontenteditableの違いを吸収する抽象化レイヤー
  - `getText()`: 要素の種類に関わらずテキスト内容を取得
  - `getTextLength()`: テキストの長さを取得
  - `getSelectionRange()`: Range APIを使用して選択範囲を取得
  - `setSelectionRange()`: Range APIを使用して選択範囲を設定
  - `isContentEditable()`: contenteditable要素かを判定

### 修正ファイル
- `src/utils/types.ts`: 型定義をHTMLElementを含むように拡張
- `src/utils/getElement.ts`: contenteditable要素を受け入れるように修正
- `src/utils/getLines.ts`: element.valueの代わりにgetText()ヘルパーを使用
- `src/utils/insertText.ts`: contenteditableでのテキスト挿入に対応
- `src/utils/handleKeyDown.ts`: テキストと選択範囲の操作に抽象化ヘルパーを使用
- `src/commands/common.ts`: getText()ヘルパーを使用（2箇所）
- `src/commands/insert.ts`: 抽象化ヘルパーを使用（3箇所）
- `src/commands/normal.ts`: getText()ヘルパーを使用（約15箇所）、複数行チェックを更新
- `src/commands/visual.ts`: getText()とgetSelectionRange()ヘルパーを使用（3箇所）
- `dev/index.html`: テスト用にcontenteditable divを追加
- `dev/style.css`: contenteditable要素のスタイルを更新

## 技術詳細
- ContentEditableのテキストはtextContentを使用して取得し、HTMLタグをプレーンテキストに変換
- 選択範囲はwindow.getSelection()とRange APIで管理
- 改行は\nに正規化（<br>やブロック要素を変換）
- 既存のINPUT/TEXTAREA機能との後方互換性を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)